### PR TITLE
Generate devices based on the shades

### DIFF
--- a/custom_components/espsomfy_rts/binary_sensor.py
+++ b/custom_components/espsomfy_rts/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, EVT_CONNECTED, EVT_GROUPSTATE, EVT_SHADESTATE
 from .controller import ESPSomfyController
-from .entity import ESPSomfyEntity
+from .entity import ESPSomfyShadeEntity
 
 
 async def async_setup_entry(
@@ -54,7 +54,7 @@ async def async_setup_entry(
         async_add_entities(new_entities)
 
 
-class ESPSomfySunSensor(ESPSomfyEntity, BinarySensorEntity):
+class ESPSomfySunSensor(ESPSomfyShadeEntity, BinarySensorEntity):
     """A sun flag sensor indicating whether there is sun."""
 
     def __init__(self, controller: ESPSomfyController, data) -> None:
@@ -123,7 +123,7 @@ class ESPSomfySunSensor(ESPSomfyEntity, BinarySensorEntity):
         return self._available
 
 
-class ESPSomfyWindSensor(ESPSomfyEntity, BinarySensorEntity):
+class ESPSomfyWindSensor(ESPSomfyShadeEntity, BinarySensorEntity):
     """A sun flag sensor indicating whether there is sun."""
 
     def __init__(self, controller: ESPSomfyController, data) -> None:

--- a/custom_components/espsomfy_rts/cover.py
+++ b/custom_components/espsomfy_rts/cover.py
@@ -32,7 +32,7 @@ from .const import (
     EVT_SHADESTATE,
 )
 from .controller import ESPSomfyController
-from .entity import ESPSomfyEntity
+from .entity import ESPSomfyShadeEntity
 
 SVC_OPEN_SHADE = "open_shade"
 SVC_CLOSE_SHADE = "close_shade"
@@ -183,14 +183,14 @@ async def async_setup_entry(
         )
 
 
-class ESPSomfyGroup(CoverGroup, ESPSomfyEntity):
+class ESPSomfyGroup(CoverGroup, ESPSomfyShadeEntity):
     """A grpi[] that is associated with a controller."""
 
     def __init__(
         self, hass: HomeAssistant, controller: ESPSomfyController, data
     ) -> None:
         """Initialize a group."""
-        ESPSomfyEntity.__init__(self=self, controller=controller, data=data)
+        ESPSomfyShadeEntity.__init__(self=self, controller=controller, data=data)
         self._hass = hass
         self._attr_available = True
         self._controller = controller
@@ -342,7 +342,7 @@ class ESPSomfyGroup(CoverGroup, ESPSomfyEntity):
         await self._controller.api.group_command(cmd)
 
 
-class ESPSomfyShade(ESPSomfyEntity, CoverEntity):
+class ESPSomfyShade(ESPSomfyShadeEntity, CoverEntity):
     """A shade that is associated with a controller."""
 
     def __init__(self, controller: ESPSomfyController, data) -> None:

--- a/custom_components/espsomfy_rts/entity.py
+++ b/custom_components/espsomfy_rts/entity.py
@@ -34,3 +34,23 @@ class ESPSomfyEntity(CoordinatorEntity[ESPSomfyController], Entity):
             sw_version=self.controller.version,
             hw_version=None,
         )
+
+
+class ESPSomfyShadeEntity(ESPSomfyEntity):
+    """Base entity for ESPSomfy shades."""
+
+    def __init__(self, *, data: any, controller: ESPSomfyController) -> None:
+        """Initialize the entity."""
+        super().__init__(data=data, controller=controller)
+        self._data = data
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Device info."""
+        return DeviceInfo(
+            configuration_url=self.controller.api.get_config_url(),
+            identifiers={
+                (DOMAIN, f"{self.controller.unique_id}_shade_{self._data['shadeId']}"),
+            },
+            name=self._data["name"],
+        )

--- a/custom_components/espsomfy_rts/switch.py
+++ b/custom_components/espsomfy_rts/switch.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, EVT_CONNECTED, EVT_GROUPSTATE, EVT_SHADESTATE
 from .controller import ESPSomfyController
-from .entity import ESPSomfyEntity
+from .entity import ESPSomfyShadeEntity
 
 
 async def async_setup_entry(
@@ -60,7 +60,7 @@ async def async_setup_entry(
         async_add_entities(new_entities)
 
 
-class ESPSomfySunSwitch(ESPSomfyEntity, SwitchEntity):
+class ESPSomfySunSwitch(ESPSomfyShadeEntity, SwitchEntity):
     """A sun flag switch for toggling sun mode."""
 
     def __init__(self, controller: ESPSomfyController, data) -> None:
@@ -145,7 +145,7 @@ class ESPSomfySunSwitch(ESPSomfyEntity, SwitchEntity):
         return self._available
 
 
-class ESPSomfyBinarySwitch(ESPSomfyEntity, SwitchEntity):
+class ESPSomfyBinarySwitch(ESPSomfyShadeEntity, SwitchEntity):
     """A binary switch for toggling a dry contact."""
 
     def __init__(self, controller: ESPSomfyController, data) -> None:


### PR DESCRIPTION
Instead of having all the shades in the same device entry, generate a device entry per shade with the shade's control al sensors and a device for the ESPSomfy-RTS device itself that contains configuration and diagnostic information.